### PR TITLE
[ISSUE 9] Request constructing bugfix

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -92,7 +92,7 @@ impl <'a> Request<'a> {
         let hostname = parse_hostname(url);
         let path = match parse_path(url) {
             Some(p) => Some(format!("/{}", p)),
-            None => panic!("Failed to parse path of {}", url)
+            None => None
         };
 
         Self {


### PR DESCRIPTION
### Issue 9
Request's constructing fails while constructing new object from an url without any path.

### Explanation
The `match` operator was appending the `path` if any `path` found, otherwise it was panicking.
Right now it returns `None` instead of panicking.